### PR TITLE
Release in Maven central

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,1 @@
+Follow https://central.sonatype.org/pages/apache-maven.html

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When serializing, we know the topic we want to send the message to and we have t
 we need to get the schema to use for serialization and subject to verify the schema in the schema registry. 
  
 ## DefaultJacksonKafkaAvroSerializer
-You can use `com.productboard.kafka.serializers.DefaultJacksonKafkaAvroSerializer` which uses [TopicNameStrategy](https://docs.confluent.io/current/schema-registry/serdes-develop/index.html#how-the-naming-strategies-work) to derive
+You can use `DefaultJacksonKafkaAvroSerializer` which uses [TopicNameStrategy](https://docs.confluent.io/current/schema-registry/serdes-develop/index.html#how-the-naming-strategies-work) to derive
 the subject. Then it looks for `avro_schemas/{subject}.avsc` file in your classpath. If you are sending messages to topic 'topic', it will try to load the schema from `avro_schemas/topic-value.avsc`.
 See the  [source](https://github.com/productboardlabs/jackson-kafka-avro-serializer/blob/master/src/main/java/com/productboard/kafka/serializers/DefaultJacksonKafkaAvroSerializer.java) for details.
 
@@ -23,39 +23,32 @@ Unfortunately, you can not use `RecordNameStrategy` or `TopicRecordNameStrategy`
 of the record without finding the schema first. 
 
 ## AbstractJacksonKafkaAvroSerializer
-For more complex scenarios extend `com.productboard.kafka.serializers.AbstractJacksonKafkaAvroSerializer` and implement the 
+For more complex scenarios extend `AbstractJacksonKafkaAvroSerializer` and implement the 
 schema resolution by yourself, it's quite easy, just implement the `getSchemaFor(String topic, Object value)` method.
 
 ## Deserialization
 When deserializing, we have the schema and the topic name for which we need to find the class to deserialize to.
 
 ## DefaultJacksonKafkaAvroDeserializer
-`com.productboard.kafka.serializers.DefaultJacksonKafkaAvroDeserializer` takes the fully qualified record name and tries to
+`DefaultJacksonKafkaAvroDeserializer` takes the fully qualified record name and tries to
 deserialize to class with the same qualified name. If you need to change the class-name or package name, just override the
 `getClassName(String topic, Schema schema)` method.
 
 ## AbstractJacksonKafkaAvroDeserializer
-If you need anything more complex, just implement `com.productboard.kafka.serializers.AbstractJacksonKafkaAvroDeserializer` 
+If you need anything more complex, just implement `AbstractJacksonKafkaAvroDeserializer` 
 and its`getClassFor(String topic, Schema schema)` method.
 
 # Installation
-The package is available at JCenter.
+The package is available at Maven Central.
 
 ## Maven
 
 ```xml
-<repositories>
-    <repository>
-      <id>jcenter</id>
-      <url>https://jcenter.bintray.com/</url>
-    </repository>
-</repositories>
-
 <dependencies>
     <dependency>
-        <groupId>com.productboard</groupId>
+        <groupId>io.github.productboardlabs</groupId>
         <artifactId>jackson-kafka-avro-serializer</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0</version>
     </dependency>
 </dependencies>
 ``` 
@@ -73,6 +66,8 @@ implementation("com.productboard:jackson-kafka-avro-serializer:0.3.0")
 
 
 # Release notes
+
+### 0.4.0 - Released to Maven cetntral - groupId and package name changed
 
 ### 0.3.0 - Upgrade to kafka-avro-serializer 6.0.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.productboard</groupId>
+    <groupId>io.github.productboardlabs</groupId>
     <artifactId>jackson-kafka-avro-serializer</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0</version>
 
     <name>jackson-kafka-avro-serializer</name>
     <url>https://github.com/productboardlabs/jackson-kafka-avro-serializer</url>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
-            <version>6.0.1</version>
+            <version>6.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -138,6 +138,62 @@
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>3.0.0-M1</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -149,12 +205,10 @@
     </repositories>
 
     <distributionManagement>
-        <repository>
-            <id>bintray-productboardlabs</id>
-            <name>productboardlabs-jackson-kafka-avro-serializer</name>
-            <url>https://api.bintray.com/maven/productboardlabs/maven-repo/jackson-kafka-avro-serializer/;publish=1
-            </url>
-        </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <scm>

--- a/src/main/java/io/github/productboardlabs/kafka/serializers/AbstractJacksonKafkaAvroDeserializer.java
+++ b/src/main/java/io/github/productboardlabs/kafka/serializers/AbstractJacksonKafkaAvroDeserializer.java
@@ -1,4 +1,4 @@
-package com.productboard.kafka.serializers;
+package io.github.productboardlabs.kafka.serializers;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.avro.AvroMapper;

--- a/src/main/java/io/github/productboardlabs/kafka/serializers/AbstractJacksonKafkaAvroSerializer.java
+++ b/src/main/java/io/github/productboardlabs/kafka/serializers/AbstractJacksonKafkaAvroSerializer.java
@@ -1,4 +1,4 @@
-package com.productboard.kafka.serializers;
+package io.github.productboardlabs.kafka.serializers;
 
 import com.fasterxml.jackson.dataformat.avro.AvroMapper;
 import com.fasterxml.jackson.dataformat.avro.AvroSchema;

--- a/src/main/java/io/github/productboardlabs/kafka/serializers/ClassNotFoundDeserializationException.java
+++ b/src/main/java/io/github/productboardlabs/kafka/serializers/ClassNotFoundDeserializationException.java
@@ -1,4 +1,4 @@
-package com.productboard.kafka.serializers;
+package io.github.productboardlabs.kafka.serializers;
 
 import org.apache.kafka.common.errors.SerializationException;
 

--- a/src/main/java/io/github/productboardlabs/kafka/serializers/DefaultJacksonKafkaAvroDeserializer.java
+++ b/src/main/java/io/github/productboardlabs/kafka/serializers/DefaultJacksonKafkaAvroDeserializer.java
@@ -1,7 +1,6 @@
-package com.productboard.kafka.serializers;
+package io.github.productboardlabs.kafka.serializers;
 
 import org.apache.avro.Schema;
-import org.apache.kafka.common.errors.SerializationException;
 import org.jetbrains.annotations.NotNull;
 
 public class DefaultJacksonKafkaAvroDeserializer extends AbstractJacksonKafkaAvroDeserializer {

--- a/src/main/java/io/github/productboardlabs/kafka/serializers/DefaultJacksonKafkaAvroSerializer.java
+++ b/src/main/java/io/github/productboardlabs/kafka/serializers/DefaultJacksonKafkaAvroSerializer.java
@@ -1,10 +1,10 @@
-package com.productboard.kafka.serializers;
+package io.github.productboardlabs.kafka.serializers;
 
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 
-import static com.productboard.kafka.serializers.Utils.parseSchema;
+import static io.github.productboardlabs.kafka.serializers.Utils.parseSchema;
 
 public class DefaultJacksonKafkaAvroSerializer extends AbstractJacksonKafkaAvroSerializer {
     private boolean isKey;

--- a/src/main/java/io/github/productboardlabs/kafka/serializers/SchemaMetadata.java
+++ b/src/main/java/io/github/productboardlabs/kafka/serializers/SchemaMetadata.java
@@ -1,4 +1,4 @@
-package com.productboard.kafka.serializers;
+package io.github.productboardlabs.kafka.serializers;
 
 import org.apache.avro.Schema;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/io/github/productboardlabs/kafka/serializers/Utils.java
+++ b/src/main/java/io/github/productboardlabs/kafka/serializers/Utils.java
@@ -1,4 +1,4 @@
-package com.productboard.kafka.serializers;
+package io.github.productboardlabs.kafka.serializers;
 
 import com.fasterxml.jackson.dataformat.avro.AvroMapper;
 import org.apache.avro.Schema;

--- a/src/test/java/io/github/productboardlabs/kafka/serializers/AbstractJacksonKafkaAvroDeserializerTest.java
+++ b/src/test/java/io/github/productboardlabs/kafka/serializers/AbstractJacksonKafkaAvroDeserializerTest.java
@@ -1,4 +1,4 @@
-package com.productboard.kafka.serializers;
+package io.github.productboardlabs.kafka.serializers;
 
 
 import example.avro.User;
@@ -12,7 +12,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
-import static com.productboard.kafka.serializers.TestData.*;
+import static io.github.productboardlabs.kafka.serializers.TestData.defaultConfig;
+import static io.github.productboardlabs.kafka.serializers.TestData.generatedUser;
+import static io.github.productboardlabs.kafka.serializers.TestData.simpleUser;
+import static io.github.productboardlabs.kafka.serializers.TestData.topic;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AbstractJacksonKafkaAvroDeserializerTest {

--- a/src/test/java/io/github/productboardlabs/kafka/serializers/DefaultJacksonKafkaAvroDeserializerTest.java
+++ b/src/test/java/io/github/productboardlabs/kafka/serializers/DefaultJacksonKafkaAvroDeserializerTest.java
@@ -1,10 +1,12 @@
-package com.productboard.kafka.serializers;
+package io.github.productboardlabs.kafka.serializers;
 
 
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import org.junit.jupiter.api.Test;
 
-import static com.productboard.kafka.serializers.TestData.*;
+import static io.github.productboardlabs.kafka.serializers.TestData.defaultConfig;
+import static io.github.productboardlabs.kafka.serializers.TestData.generatedUser;
+import static io.github.productboardlabs.kafka.serializers.TestData.topic;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DefaultJacksonKafkaAvroDeserializerTest {

--- a/src/test/java/io/github/productboardlabs/kafka/serializers/DefaultJacksonKafkaAvroSerializerTest.java
+++ b/src/test/java/io/github/productboardlabs/kafka/serializers/DefaultJacksonKafkaAvroSerializerTest.java
@@ -1,4 +1,4 @@
-package com.productboard.kafka.serializers;
+package io.github.productboardlabs.kafka.serializers;
 
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -15,8 +15,11 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static com.productboard.kafka.serializers.TestData.*;
-import static com.productboard.kafka.serializers.Utils.parseSchema;
+import static io.github.productboardlabs.kafka.serializers.TestData.defaultConfig;
+import static io.github.productboardlabs.kafka.serializers.TestData.generatedUser;
+import static io.github.productboardlabs.kafka.serializers.TestData.simpleUser;
+import static io.github.productboardlabs.kafka.serializers.TestData.topic;
+import static io.github.productboardlabs.kafka.serializers.Utils.parseSchema;
 import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS;
 import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG;
 import static io.confluent.kafka.serializers.KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG;

--- a/src/test/java/io/github/productboardlabs/kafka/serializers/SimpleUser.java
+++ b/src/test/java/io/github/productboardlabs/kafka/serializers/SimpleUser.java
@@ -1,4 +1,4 @@
-package com.productboard.kafka.serializers;
+package io.github.productboardlabs.kafka.serializers;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/test/java/io/github/productboardlabs/kafka/serializers/TestData.java
+++ b/src/test/java/io/github/productboardlabs/kafka/serializers/TestData.java
@@ -1,4 +1,4 @@
-package com.productboard.kafka.serializers;
+package io.github.productboardlabs.kafka.serializers;
 
 import example.avro.User;
 import org.junit.jupiter.params.provider.Arguments;

--- a/src/test/kotlin/io/github/productboardlabs/kafka/serializers/KotlinTest.kt
+++ b/src/test/kotlin/io/github/productboardlabs/kafka/serializers/KotlinTest.kt
@@ -1,6 +1,6 @@
-package com.productboard.kafka.serializers
+package io.github.productboardlabs.kafka.serializers
 
-import com.productboard.kafka.serializers.TestData.topic
+import io.github.productboardlabs.kafka.serializers.TestData.topic
 import org.apache.avro.Schema
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -23,6 +23,6 @@ class KotlinTest {
 
 private class MyKotlinJacksonKafkaAvroDeserializer : DefaultJacksonKafkaAvroDeserializer() {
     override fun getClassName(topic: String, schema: Schema): String {
-        return "com.productboard.kafka.serializers.${schema.name}Kotlin"
+        return "io.github.productboardlabs.kafka.serializers.${schema.name}Kotlin"
     }
 }

--- a/src/test/kotlin/io/github/productboardlabs/kafka/serializers/UserKotlin.kt
+++ b/src/test/kotlin/io/github/productboardlabs/kafka/serializers/UserKotlin.kt
@@ -1,4 +1,4 @@
-package com.productboard.kafka.serializers
+package io.github.productboardlabs.kafka.serializers
 
 import com.fasterxml.jackson.annotation.JsonProperty
 


### PR DESCRIPTION
The package name change was not strictly necessary but there is a risk of having both JARs in the classpath due to transitive dependency and then it's better to be able to tell which JAR should be used.